### PR TITLE
fix skyline spacing issue on Firefox

### DIFF
--- a/src/sass/modules/home/_intro.component.scss
+++ b/src/sass/modules/home/_intro.component.scss
@@ -15,7 +15,7 @@ aq-intro {
 
     .text-content {
         height: 100%;
-        margin-bottom: calc(#{$skyline-foreground-height} + 15px);
+        padding-bottom: calc(#{$skyline-foreground-height} + 15px);
         position: relative;
         z-index: 5;
 


### PR DESCRIPTION
Small change in CSS to fix [error happening solely on Firefox](https://screenshots.firefox.com/PcQbnfEVysu1TONG/localhost) where `margin-bottom` was not being applied as intended.

[Updating the spacing to padding instead of margin](https://screenshots.firefox.com/EnBcIwgZNCUj1qBX/localhost) fixes this behavior in FIrefox while maintain functionality in other browsers.